### PR TITLE
Fix WiFi logging tag casing

### DIFF
--- a/main/communications/rg_wifi.h
+++ b/main/communications/rg_wifi.h
@@ -8,7 +8,7 @@
 // Define the Wi-Fi manager NVS namespace
 static const char *wifi_manager_nvs_namespace = "espwifimgr";
 
-static const std::string WTEMPTAG = std::string(DEVICE_NAME) + "-" + DEVICE_VERSION + "::Wifi";
+static const std::string WTEMPTAG = std::string(DEVICE_NAME) + "-" + DEVICE_VERSION + "::WiFi";
 static const char *WIFI_TAG = WTEMPTAG.c_str();
 
 void cb_connection_ok(void *pvParameter) {


### PR DESCRIPTION
## Summary
- adjust WiFi tag casing to be consistent

## Testing
- `bash run_build.sh` *(fails: esp-idf not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f47aabc8c8326abffae4dc0cb45b0