### PR TITLE
Adjust commit logic in reset_wifi_provisioning

### DIFF
--- a/main/communications/rg_wifi.h
+++ b/main/communications/rg_wifi.h
@@ -46,11 +46,10 @@ void reset_wifi_provisioning(void) {
         } else {
             ESP_LOGE(WIFI_TAG, "Failed to erase Wi-Fi provisioning data: %s", esp_err_to_name(err));
         }
+        // Commit changes to NVS before closing the handle
+        nvs_commit(handle);
         nvs_close(handle);
     } else {
         ESP_LOGE(WIFI_TAG, "Failed to open NVS: %s", esp_err_to_name(err));
     }
-
-    // Commit changes to NVS
-    nvs_commit(handle);
 }


### PR DESCRIPTION
## Summary
- move `nvs_commit` into success block of `reset_wifi_provisioning`
- commit changes before closing NVS handle

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f47c7e55483268a3f929e25617f15