### PR TITLE
Add Unity test for rg_bme280

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.16)
 # Add the esp-matter path to the component search paths
 # This allows idf_component.yml to find components like esp_matter, openthread, etc.
 set(EXTRA_COMPONENT_DIRS ${ESP_MATTER_PATH})
+list(APPEND EXTRA_COMPONENT_DIRS ${CMAKE_CURRENT_LIST_DIR}/tests)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(rg2)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "test_rg_bme280.c" PRIV_REQUIRES unity main)

--- a/tests/test_rg_bme280.c
+++ b/tests/test_rg_bme280.c
@@ -1,0 +1,17 @@
+#include "unity.h"
+#include "rg_bme280.h"
+
+TEST_CASE("rg_bme280_read_values returns invalid arg on NULL parameters", "[rg_bme280]")
+{
+    rg_bme280_t dev = {0};
+    (void)dev;
+    esp_err_t err = rg_bme280_read_values(NULL, NULL);
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, err);
+}
+
+void app_main(void)
+{
+    UNITY_BEGIN();
+    unity_run_all_tests();
+    UNITY_END();
+}


### PR DESCRIPTION
## Summary
- register a `tests` component with Unity
- add simple unit test for `rg_bme280_read_values`
- include test component in main build

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f47cd6df483269ae73ad9e4a6b7aa